### PR TITLE
HIL testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,16 @@ VERSION=0x03
 
 FTPUSER ?=joshc
 
+TST_FILES_ALL := $(wildcard tests/Test*.py)
+TST_FILES_LOCAL := $(filter-out tests/TestHIL.py, $(TST_FILES_ALL))
+
 .PHONY: test
 test:
-	@source venv/bin/activate && pytest --capture=tee-sys -vv tests/Test*.py
+	@source venv/bin/activate && pytest --capture=tee-sys -vv $(TST_FILES_LOCAL)
+
+.PHONY: test_all
+test_all:
+	@source venv/bin/activate && pytest --capture=tee-sys -vv $(TST_FILES_ALL)
 
 .PHONY: update_drops
 update_drops:
@@ -17,4 +24,4 @@ run_test_server:
 
 .PHONY: transfer_working_files
 transfer_working_files:
-	rsync -zvaP tests drops $(FTPUSER)@psbuild-rhel7:~/DoDRobotCode/
+	rsync -zvaP Makefile setup.py tests drops $(FTPUSER)@psbuild-rhel7:~/DoDRobotCode/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 SHELL:=/bin/bash
 VERSION=0x03
 
+FTPUSER ?=joshc
+
 .PHONY: test
 test:
-	@source venv/bin/activate && pytest --capture=tee-sys tests/Test*.py
+	@source venv/bin/activate && pytest --capture=tee-sys -vv tests/Test*.py
 
 .PHONY: update_drops
 update_drops:
@@ -12,3 +14,7 @@ update_drops:
 .PHONY: run_test_server
 run_test_server:
 	@python3 tests/testServer.py
+
+.PHONY: transfer_working_files
+transfer_working_files:
+	rsync -zvaP tests drops $(FTPUSER)@psbuild-rhel7:~/DoDRobotCode/

--- a/drops/DropsDriver.py
+++ b/drops/DropsDriver.py
@@ -46,14 +46,14 @@ class myClient:
     self.__PORT__ = port
     self.conn = HTTPConnection(host=self.__IP__, port=self.__PORT__)
     self.transceiver = HTTPTransceiver(self.conn, self.__queue__, self.__queue_ready__)
+    logger.info(f"Connected to ip: {ip} port: {port}")
+    
     # configuration persitence, updating
     self.supported_ends_handler = SupportedEndsHandler(supported_json,
                                                        self.conn)
-
     if (reload):
       self.supported_ends_handler.reload_all()
 
-    logger.info(f"Connected to ip: {ip} port: {port}")
     # convinient member lambda for grabbing supported endpoitns
     self.supported_ends = lambda : self.supported_ends_handler.get_endpoints()
     pprint.pprint(self.supported_ends())
@@ -80,9 +80,7 @@ class myClient:
       """
         Required to send 'Do' requests
       """
-      print("here")
       self.send("/DoD/Connect?ClientName={value}")
-      print("now here")
 
   def disconnect(self):
       """
@@ -188,7 +186,6 @@ class myClient:
   it will persist result in a place that can be read... TODO: actually do this
   '''
   def send(self, endpoint):
-    print("HEEERE")
     self.transceiver.send(endpoint)
     return
 

--- a/drops/DropsDriver.py
+++ b/drops/DropsDriver.py
@@ -56,13 +56,21 @@ class myClient:
     self.supported_ends = lambda : self.supported_ends_handler.get_endpoints()
     pprint.pprint(self.supported_ends())
 
+  def middle_invocation_wrapper(func):
+    def inner(self):
+      logger.info(f"Invoking {func.__name__}")
+      func(self)
+      return self.get_response()
+    return inner
+
+  @middle_invocation_wrapper
   def connect(self):
       """
         Required to send 'Do' requests
       """
-      logger.info(f"Sending: /DoD/Connect")
-      self.send("/DoD/Connect")
-      return self.get_response()
+      print("here")
+      self.send("/DoD/Connect?ClientName=egg")
+      print("now here")
 
   def disconnect(self):
       """
@@ -72,14 +80,13 @@ class myClient:
       logger.info(f"Sending: /DoD/Disconnect")
       self.send("/DoD/Disconnect")
       return self.get_response()
-
+  
+  @middle_invocation_wrapper
   def get_status(self):
       """
         Returns Robot Status
       """
-      logger.info(f"Sending: /DoD/get/Status")
       self.send("/DoD/get/Status")
-      return self.get_response()
 
   def move(self, position : str):
       """

--- a/drops/helpers/JsonFileHandler.py
+++ b/drops/helpers/JsonFileHandler.py
@@ -1,6 +1,7 @@
 import json
 import pprint
 
+
 class JsonFileHandler:
     """
         Handle supported.json file
@@ -23,8 +24,5 @@ class JsonFileHandler:
 
         file_fd.close()
 
-
     def get_endpoint_data(self, endpoint : str):
         return self.endpoints[self.capabilities[endpoint]]['payload']
-
-

--- a/drops/helpers/ServerResponse.py
+++ b/drops/helpers/ServerResponse.py
@@ -6,11 +6,12 @@ class ServerResponse:
         Object for parsing incomming HTTPResponse from Robot
     """
     def __init__(self, httObj: HTTPResponse):
-        response = json.loads(httObj.read())
+        dat = httObj.read().decode('utf-8')
+        response = json.loads(dat)
         self.TIME = response["Time"]
         self.STATUS = response["Status"]
         self.LAST_ID = response["LastID"]
         self.ERROR_CODE = response["ErrorCode"]
         self.ERROR_MESSAGE = response["ErrorMessage"]
-        self.RESULTS = response["Results"]
+        self.RESULTS = response["Result"]
 

--- a/drops/helpers/SupporEndsHandler.py
+++ b/drops/helpers/SupporEndsHandler.py
@@ -9,9 +9,12 @@ from drops.helpers.ServerResponse import ServerResponse
 logger = logging.getLogger(__name__)
 
 
+# TODO: all file io should go through JsonFileHandler, this class should only concern itself with 
+# the logic of interacting with the actual to update our notion of what endpoints the machine supports and the arguments those take
+# because the machine is the source of truth for what API is provided
 class SupportedEndsHandler:
     """
-        Class ment to handle supported endpoints Json file.
+        Class meant to handle supported endpoints Json file.
             Reloads endpoints, keeps track of API args, and possible 'do' actions
 
             TODO: Write updates to JSON file?

--- a/tests/TestHIL.py
+++ b/tests/TestHIL.py
@@ -1,0 +1,30 @@
+import json
+
+from drops.DropsDriver import myClient
+from drops.helpers.JsonFileHandler import JsonFileHandler
+
+# pytest encourages this pattern, apologies.
+ip = "172.21.148.101"
+port = 9999
+supported_json = "drops/supported.json"
+# instantiate HTTP client
+client = myClient(ip=ip, port=port, supported_json=supported_json, reload=False)
+# create config parser handler
+json_handler = JsonFileHandler(supported_json)
+# load configs and launch web server 
+json_handler.reload_endpoints()
+
+class TestHIL:
+  # Responses in which the values corresponding keys dont matter
+  def test_disconnect(self, capsys):
+    resp = client.disconnect()
+    assert resp.RESULTS == json_handler.get_endpoint_data("/DoD/Disconnect")
+  
+  def test_connect(self, capsys):
+    # TEST Connect
+    print(client)
+    client.disconnect()
+    resp = client.connect()
+    assert resp.RESULTS == json_handler.get_endpoint_data("/DoD/Connect?ClientName={value}")
+
+  

--- a/tests/TestResponse.py
+++ b/tests/TestResponse.py
@@ -10,20 +10,38 @@ supported_json = "drops/supported.json"
 
 
 class TestResponse:
-    def test_get_status(self, capsys):
-        # instantiate HTTP client
-        client = myClient(ip=ip, port=port, supported_json=supported_json, reload=False)
-        # spawn test backend
-        web_server = ServerSpawner(ip, port, supported_json)
-        # create config parser handler
-        json_handler = JsonFileHandler(supported_json)
+  def test_get_status(self, capsys):
+    # instantiate HTTP client
+    client = myClient(ip=ip, port=port, supported_json=supported_json, reload=False)
+    # spawn test backend
+    web_server = ServerSpawner(ip, port, supported_json)
+    # create config parser handler
+    json_handler = JsonFileHandler(supported_json)
 
-        # load configs and launch web server 
-        json_handler.reload_endpoints()
-        web_server.launch_web_server()
+    # load configs and launch web server 
+    json_handler.reload_endpoints()
+    web_server.launch_web_server()
 
-        # TEST Status
-        resp = client.get_status()
-        web_server.kill_web_server()
-        print(f"got response {resp}")
-        assert resp.RESULTS == json_handler.get_endpoint_data("/DoD/get/Status")
+    # TEST Status
+    resp = client.get_status()
+    web_server.kill_web_server()
+    print(f"got response {resp}")
+    assert resp.RESULTS == json_handler.get_endpoint_data("/DoD/get/Status")
+
+  # def test_do_connect(self, capsys):
+  #   # instantiate HTTP client
+  #   client = myClient(ip=ip, port=port, supported_json=supported_json, reload=False)
+  #   # spawn test backend
+  #   web_server = ServerSpawner(ip, port, supported_json)
+  #   # create config parser handler
+  #   json_handler = JsonFileHandler(supported_json)
+
+  #   # load configs and launch web server 
+  #   json_handler.reload_endpoints()
+  #   web_server.launch_web_server()
+  #   # TEST Connect
+  #   print(client)
+  #   resp = client.connect()
+  #   web_server.kill_web_server()
+  #   print(f"got response {resp}")
+  #   assert resp.RESULTS == json_handler.get_endpoint_data("/DoD/Connect?ClientName={value}")

--- a/tests/TestResponse.py
+++ b/tests/TestResponse.py
@@ -8,40 +8,21 @@ ip = "127.0.0.1"
 port = 8081
 supported_json = "drops/supported.json"
 
+# pytest encourages this pattern, apologies.
+# instantiate HTTP client
+client = myClient(ip=ip, port=port, supported_json=supported_json, reload=False)
+# spawn test backend
+web_server = ServerSpawner(ip, port, supported_json)
+# create config parser handler
+json_handler = JsonFileHandler(supported_json)
+# load configs and launch web server 
+json_handler.reload_endpoints()
 
 class TestResponse:
-  def test_get_status(self, capsys):
-    # instantiate HTTP client
-    client = myClient(ip=ip, port=port, supported_json=supported_json, reload=False)
-    # spawn test backend
-    web_server = ServerSpawner(ip, port, supported_json)
-    # create config parser handler
-    json_handler = JsonFileHandler(supported_json)
-
-    # load configs and launch web server 
-    json_handler.reload_endpoints()
-    web_server.launch_web_server()
-
-    # TEST Status
-    resp = client.get_status()
-    web_server.kill_web_server()
-    print(f"got response {resp}")
-    assert resp.RESULTS == json_handler.get_endpoint_data("/DoD/get/Status")
-
-  # def test_do_connect(self, capsys):
-  #   # instantiate HTTP client
-  #   client = myClient(ip=ip, port=port, supported_json=supported_json, reload=False)
-  #   # spawn test backend
-  #   web_server = ServerSpawner(ip, port, supported_json)
-  #   # create config parser handler
-  #   json_handler = JsonFileHandler(supported_json)
-
-  #   # load configs and launch web server 
-  #   json_handler.reload_endpoints()
-  #   web_server.launch_web_server()
-  #   # TEST Connect
-  #   print(client)
-  #   resp = client.connect()
-  #   web_server.kill_web_server()
-  #   print(f"got response {resp}")
-  #   assert resp.RESULTS == json_handler.get_endpoint_data("/DoD/Connect?ClientName={value}")
+    def test_get_status(self, capsys):
+        web_server.launch_web_server()
+        # TEST Status
+        resp = client.get_status()
+        web_server.kill_web_server()
+        print(f"got response {resp}")
+        assert resp.RESULTS == json_handler.get_endpoint_data("/DoD/get/Status")

--- a/tests/testServer.py
+++ b/tests/testServer.py
@@ -55,7 +55,7 @@ class MyServer(BaseHTTPRequestHandler):
         # Respond to Client
         payLoad = endpoints[capabilities[command]]["payload"]
         header = data['header']
-        header["Results"] = payLoad
+        header["Result"] = payLoad
 
         payLoad = json.dumps(header, ensure_ascii=False)
         self.send_response(200)


### PR DESCRIPTION
## Summary of updates:
- `Makefile` : 
  - added a convenience phony to upload files to tst-console (requires FTPUSER environment var be defined)
  - updated notion of  `make test` vs `make test_all`, where **only** `make test_all` runs HIL tests
- `DropsDriver` :
  -  added command line args for connect and disconnect. 
  - Added py decorator for functions that call low level HTTP interactions
- `ServerResponse` : 
  - Explicitly decoded the bytes we get off the line. **Schema Change** the header field that _was_ "Results" is **now** "Result"
  - Had to propagate change to `testServer.py` to keep HIL and mock server in line
- `TestHIL`:
  - Runs hardware in the loop testing on the actual machine. 