### PR TITLE
Drops Driver state machine

### DIFF
--- a/drops/DropsDriver.py
+++ b/drops/DropsDriver.py
@@ -75,6 +75,7 @@ class myClient:
   def __del__(self):
       # close network connection
       self.conn.close()
+      self.worker.do_work.value = False
       self.worker_process.join()
 
   '''
@@ -91,10 +92,12 @@ class myClient:
     def inner(self, blocking=True, *args):
       logger.info(f"Invoking {func.__name__}")
       func(self, *args)
+
+      #Keep original functionality
       if blocking:
           # NOTE: It is possible to do not blocking request, then in next
           # blocking request receive from previous not blocking request
-          return self.get_response(blocking) # return Items when we have them
+          return self.out_qeue.get(block=True) # return item from Q w/ blocking
       return None # can check later
       # TODO: Do something with None response globally
       # Check if we have a GUI (get_status) that needs to be cleared, May need
@@ -395,10 +398,10 @@ class myClient:
   '''
   Pops most recent response from response queue
   '''
-  def get_response(self, blocking=True):
-    #return self.transceiver.get_response()
+  def get_response(self):
+    # prevent from blocking when there is nothing to get from Q
     if self.out_qeue.qsize() > 0:
-        return self.out_qeue.get(block=blocking)
+        return self.out_qeue.get()
     else:
         return None
     

--- a/drops/DropsDriver.py
+++ b/drops/DropsDriver.py
@@ -4,7 +4,6 @@ import argparse
 
 from http.client import HTTPConnection
 from multiprocessing import Queue, Semaphore, Process
-from threading import Thread
 from drops.helpers.ServerResponse import ServerResponse
 from drops.helpers.SupporEndsHandler import SupportedEndsHandler
 from drops.helpers.HTTPTransceiver import HTTPTransceiver
@@ -64,7 +63,7 @@ class myClient:
     self.supported_ends = lambda : self.supported_ends_handler.get_endpoints()
     pprint.pprint(self.supported_ends())
 
-    # worker thread used for handleing driver state machine
+    # worker process used for handleing driver state machine
     self.in_qeue = Queue() 
     self.out_qeue = Queue() # might need to be a stack
     self.worker =  DodRobotWorker(self.in_qeue, self.out_qeue, self.transceiver)
@@ -96,7 +95,10 @@ class myClient:
       #Keep original functionality
       if blocking:
           # NOTE: It is possible to do not blocking request, then in next
-          # blocking request receive from previous not blocking request
+          # blocking request receive from previous not blocking request.
+          # There is a time field in the Event fom Qs we can check and only
+          # return the out event that matches the in event time, this would
+          # requre the time not updated in the worker thread
           return self.out_qeue.get(block=True) # return item from Q w/ blocking
       return None # can check later
       # TODO: Do something with None response globally

--- a/drops/helpers/HTTPTransceiver.py
+++ b/drops/helpers/HTTPTransceiver.py
@@ -21,7 +21,6 @@ class HTTPTransceiver():
 
     def send(self, endpoint : str):
         logger.info(f"attempting to send: {endpoint}...")
-        print(endpoint)
         self.__conn__.request("GET", endpoint)
         logger.info("issued request")
         reply = self.__conn__.getresponse()

--- a/drops/helpers/Worker.py
+++ b/drops/helpers/Worker.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from multiprocessing import Queue
+from multiprocessing.sharedctypes import Value
 from datetime import datetime
+import time
 from drops.helpers.HTTPTransceiver import HTTPTransceiver
 
 class DodRobotWorkerStates(Enum):
@@ -9,22 +11,21 @@ class DodRobotWorkerStates(Enum):
     ERROR       = 2
 
 class DodRobotEvent():
-    def __init__(self, endpoint, blocking=True):
+    def __init__(self, endpoint):
         self.endpoint = endpoint
-        self.blocking = blocking
         self.time = datetime.now()
         self.robot_response = None
 
     def update_time(self):
         self.time = datetime.now()
-
-class DodRobotWorker(Worker):
-    CURRENT_STATE = DodRobotWorkerStates.KEEP_ALIVE
-    LAST_REQ = None
+    
+    def __str__(self):
+        return f" Endpoint: {self.endpoint}\nTime: {self.time}\n Response: {self.robot_response}"
+class DodRobotWorker():
 
     def __init__(self,
-                 in_q : Queue(DodRobotEvent),
-                 out_q : Queue(DodRobotEvent),
+                 in_q : Queue(),
+                 out_q : Queue(),
                  transceiver : HTTPTransceiver,
                  *args,
                  **kwargs):
@@ -32,40 +33,33 @@ class DodRobotWorker(Worker):
         self.in_q = in_q
         self.out_q = out_q
         self.do_next = Value('i', False)
+        self.do_work = Value('i', True)
         self.transceiver = transceiver
         self.timeout = 100 # command timeout in seconds
+        self.CURRENT_STATE = DodRobotWorkerStates.KEEP_ALIVE
+        self.LAST_REQ = None
 
     def work_func(self):
         while(self.do_work.value):
-            if CURRENT_STATE == DodRobotWorkerStates.KEEP_ALIVE:
+            if self.CURRENT_STATE == DodRobotWorkerStates.KEEP_ALIVE:
                 # KEEP CONNECTION ALIVE
                 # To keep connection alive, just prob status
-                self.transceiver.send('/Dod/get/Status')
+                self.transceiver.send('/DoD/get/Status')
                 time.sleep(0.1)
                 r = self.transceiver.get_response() # Might be good to log
 
-                if (self.LAST_REQ != None or self.LAST_REQ.blocking):
-                    ## We are blocking
-                    if(self.in_q.qsize() > 0 and self.do_next.value):
-                        #we are blocking, but its ok to continue
-                        self.do_next.value = False #reset flag, so we only do once
-                        CURRENT_STATE = DodRobotWorkerStates().ROBOT_DO
-                    else:
-                        CURRENT_STATE = DodRobotWorkerStates().KEEP_ALIVE
-
-                elif in_q.qsize() > 0:
-                    # we are not blocking and we still got items in queue
-                    CURRENT_STATE = DodRobotWorkerStates().ROBOT_DO
+                if self.in_q.qsize() > 0:
+                    # we still got items in queue
+                    self.CURRENT_STATE = DodRobotWorkerStates.ROBOT_DO
 
                 time.sleep(1)
 
-            elif CURRENT_STATE == DodRobotWorkerStates.ROBOT_DO:
+            elif self.CURRENT_STATE == DodRobotWorkerStates.ROBOT_DO:
                 # A thought, We can add some functionality to retry the command
                 # if something does not go as planned?
                 event = self.in_q.get()
 
                 self.transceiver.send(event.endpoint)
-                time.sleep(0.1) # give robot some time?
                 robot_response = self.transceiver.get_response()
 
                 # DO some busy waiting for robot to finish
@@ -84,7 +78,7 @@ class DodRobotWorker(Worker):
 
                 if robot_response.STATUS['Status'] == "Dialog":
                     # Something went wrong
-                    CURRENT_STATE = DodRobotWorkerStates.ERROR
+                    self.CURRENT_STATE = DodRobotWorkerStates.ERROR
                     # DO the same as "IDLE FOR NOW" 
                     # TODO: Handle dialog
                     event.update_time() # update new time stamp
@@ -93,14 +87,17 @@ class DodRobotWorker(Worker):
 
                 if robot_response.STATUS['Status'] == "Idle":
                     # All is good
-                    CURRENT_STATE = DodRobotWorkerStates.KEEP_ALIVE
+                    self.CURRENT_STATE = DodRobotWorkerStates.KEEP_ALIVE
                     event.update_time() # update new time stamp
                     event.robot_response = inital_response
                     self.out_q.put(event)
 
-            elif CURRENT_STATE == DodRobotWorkerStates.ERROR:
+                self.LAST_REQ = event
+
+            elif self.CURRENT_STATE == DodRobotWorkerStates.ERROR:
                 # TODO
+                print("IN EROR")
                 if self.do_next.valu:
                     #Just keep going
-                    CURRENT_STATE = DodRobotWorkerStates.KEEP_ALIVE
+                    self.CURRENT_STATE = DodRobotWorkerStates.KEEP_ALIVE
 

--- a/drops/helpers/Worker.py
+++ b/drops/helpers/Worker.py
@@ -1,0 +1,106 @@
+from enum import Enum
+from multiprocessing import Queue
+from datetime import datetime
+from drops.helpers.HTTPTransceiver import HTTPTransceiver
+
+class DodRobotWorkerStates(Enum):
+    KEEP_ALIVE  = 0
+    ROBOT_DO    = 1
+    ERROR       = 2
+
+class DodRobotEvent():
+    def __init__(self, endpoint, blocking=True):
+        self.endpoint = endpoint
+        self.blocking = blocking
+        self.time = datetime.now()
+        self.robot_response = None
+
+    def update_time(self):
+        self.time = datetime.now()
+
+class DodRobotWorker(Worker):
+    CURRENT_STATE = DodRobotWorkerStates.KEEP_ALIVE
+    LAST_REQ = None
+
+    def __init__(self,
+                 in_q : Queue(DodRobotEvent),
+                 out_q : Queue(DodRobotEvent),
+                 transceiver : HTTPTransceiver,
+                 *args,
+                 **kwargs):
+        #super().__init__(*args, **kwargs)
+        self.in_q = in_q
+        self.out_q = out_q
+        self.do_next = Value('i', False)
+        self.transceiver = transceiver
+        self.timeout = 100 # command timeout in seconds
+
+    def work_func(self):
+        while(self.do_work.value):
+            if CURRENT_STATE == DodRobotWorkerStates.KEEP_ALIVE:
+                # KEEP CONNECTION ALIVE
+                # To keep connection alive, just prob status
+                self.transceiver.send('/Dod/get/Status')
+                time.sleep(0.1)
+                r = self.transceiver.get_response() # Might be good to log
+
+                if (self.LAST_REQ != None or self.LAST_REQ.blocking):
+                    ## We are blocking
+                    if(self.in_q.qsize() > 0 and self.do_next.value):
+                        #we are blocking, but its ok to continue
+                        self.do_next.value = False #reset flag, so we only do once
+                        CURRENT_STATE = DodRobotWorkerStates().ROBOT_DO
+                    else:
+                        CURRENT_STATE = DodRobotWorkerStates().KEEP_ALIVE
+
+                elif in_q.qsize() > 0:
+                    # we are not blocking and we still got items in queue
+                    CURRENT_STATE = DodRobotWorkerStates().ROBOT_DO
+
+                time.sleep(1)
+
+            elif CURRENT_STATE == DodRobotWorkerStates.ROBOT_DO:
+                # A thought, We can add some functionality to retry the command
+                # if something does not go as planned?
+                event = self.in_q.get()
+
+                self.transceiver.send(event.endpoint)
+                time.sleep(0.1) # give robot some time?
+                robot_response = self.transceiver.get_response()
+
+                # DO some busy waiting for robot to finish
+                start = time.time()
+                delta = 0
+                inital_response = robot_response # save original response
+                while(robot_response.STATUS['Status'] == "Busy"):
+                    if delta > self.timeout:
+                        # Timeout in case something went wront
+                        self.timeout = True
+                        return #exit loop
+
+                    time.sleep(0.1) #Wait a ms to stop spamming robot
+                    robot_response = client.get_status()
+                    delta = time.time() - start
+
+                if robot_response.STATUS['Status'] == "Dialog":
+                    # Something went wrong
+                    CURRENT_STATE = DodRobotWorkerStates.ERROR
+                    # DO the same as "IDLE FOR NOW" 
+                    # TODO: Handle dialog
+                    event.update_time() # update new time stamp
+                    event.robot_response = inital_response
+                    self.out_q.put(event)
+
+                if robot_response.STATUS['Status'] == "Idle":
+                    # All is good
+                    CURRENT_STATE = DodRobotWorkerStates.KEEP_ALIVE
+                    event.update_time() # update new time stamp
+                    event.robot_response = inital_response
+                    self.out_q.put(event)
+
+            elif CURRENT_STATE == DodRobotWorkerStates.ERROR:
+                # TODO
+                if self.do_next.valu:
+                    #Just keep going
+                    CURRENT_STATE = DodRobotWorkerStates.KEEP_ALIVE
+

--- a/drops/helpers/Worker.py
+++ b/drops/helpers/Worker.py
@@ -58,7 +58,7 @@ class DodRobotWorker():
                     # we still got items in queue
                     self.CURRENT_STATE = DodRobotWorkerStates.ROBOT_DO
 
-
+                time.sleep(0.1)
             elif self.CURRENT_STATE == DodRobotWorkerStates.ROBOT_DO:
                 # A thought, We can add some functionality to retry the command
                 # if something does not go as planned?
@@ -105,7 +105,7 @@ class DodRobotWorker():
             elif self.CURRENT_STATE == DodRobotWorkerStates.ERROR:
                 # TODO
                 print("IN EROR")
-                if self.do_next.valu:
+                if self.do_next.value:
                     #Just keep going
                     self.CURRENT_STATE = DodRobotWorkerStates.KEEP_ALIVE
 

--- a/tests/HIL/common.py
+++ b/tests/HIL/common.py
@@ -16,6 +16,9 @@ json_handler = JsonFileHandler(supported_json)
 # load configs and launch web server
 json_handler.reload_endpoints()
 
+
+from datetime import datetime
+
 # Change function to "wait while busy"
 def busy_wait(timeout: int):
   '''

--- a/tests/HIL/do-test/test_do_stop_task.py
+++ b/tests/HIL/do-test/test_do_stop_task.py
@@ -12,16 +12,16 @@ def test_do_stop_task_01():
   """
   r = client.connect("Test")
   r = client.execute_task('MoveHome')
-  w = busy_wait(30)
+  w = busy_wait(60)
   assert w == False
 
   r = client.execute_task('Dab')
-  time.sleep(15)
+  time.sleep(10)
   r = client.stop_task()
   assert r.RESULTS == 'Accepted'
 
 
-  r = busy_wait(10)
+  r = busy_wait(300) # Wait for 5 min for robot to become not busy
   assert r == False
   r = client.disconnect()
 

--- a/tests/testServer.py
+++ b/tests/testServer.py
@@ -26,8 +26,13 @@ class MyServer(BaseHTTPRequestHandler):
 
         endpointIndex = 0
         for endpoint in endpoints:
-            capabilities[endpoint["API"]] = endpointIndex
+            # onlt get command without args
+            parsed_command = endpoint["API"].split('?').pop(0)
+            capabilities[parsed_command] = endpointIndex
             endpointIndex = endpointIndex + 1
+
+        print(command)
+        print(capabilities.keys())
 
         if command not in capabilities.keys():
             fd.close()


### PR DESCRIPTION
Added a state machine to handle keeping connection between client and robot. This also solves the issue of sending commands to robot when ready #14.

The original functionality is unchanged, but we can now send requests to robot in a non-blocking way.

Tested on test server. 