### PR TITLE
fix: include json file with package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,6 @@ setup(
     name="drops",
     version="0.0.1",
     packages=find_packages(),
+    include_package_data=True,
+    package_data={"drops": ["*.json"]},
 )


### PR DESCRIPTION
- Add supported.json to data included with package. This will prevent the DropsDriver myClient from starting.

Tested with:
main.py
``` Python
from drops.DropsDriver import myClient

def main():
    client = myClient(ip="127.0.0.1", port=8081)
    print(client)
    print("Hello from dod!")


if __name__ == "__main__":
    main()
```

``` bash
uv init dod
cd dod
uv add https://github.com/pcdshub/DropletOnDemand.git
uv run main.py
```